### PR TITLE
Fold scopes uniformly for repeat, reveal, and choice

### DIFF
--- a/essays/choose/essay.js
+++ b/essays/choose/essay.js
@@ -12,7 +12,7 @@ Essay.prototype.add = function (child, id, scope) {
         components.buttonLabel.value = child.value;
     } else if (id === "this") {
         this.buttons = components.buttons;
-        this.buttons.value = Object.keys(components.choose.optionConstructors);
+        this.buttons.value = Object.keys(components.choose.choices);
         this.choose = components.choose;
     }
 };

--- a/repeat.js
+++ b/repeat.js
@@ -61,18 +61,7 @@ Repetition.prototype.handleValueRangeChange = function (plus, minus, index) {
         iteration.index = index + offset;
         iteration.body = iterationNode;
 
-        var name = "iteration";
-        var scope = this.scope;
-        do {
-            var id = scope.id + ":" + name;
-            iterationScope[id] = iteration;
-            if (scope.this.add) {
-                scope.this.add(iteration, id, iterationScope);
-            }
-            name = scope.this.exports && scope.this.exports[id];
-            scope = scope.caller;
-            iterationScope = iterationScope.caller;
-        } while (name);
+        iterationScope.add(iteration, "iteration", this.scope);
 
         body.insertBefore(iterationNode, nextSibling);
         return iteration;

--- a/reveal.js
+++ b/reveal.js
@@ -11,30 +11,33 @@ function Reveal(body, scope) {
     this.observer = O.observePropertyChange(this, "value", this);
     this.body = body;
     this.scope = scope;
-    this.childConstructor = scope.argument.component;
-    this.child = null;
-    this.childBody = null;
+    this.Revelation = scope.argument.component;
+    this.revelation = null;
+    this.revelationBody = null;
+    this.revelationScope = null;
 }
 
 Reveal.prototype.handleValuePropertyChange = function (value) {
-    if (value) {
-        if (!this.child) {
-            this.constructChild();
+    if (this.revelation) {
+        if (this.revelation.destroy) {
+            this.revelation.destroy();
         }
-        this.body.appendChild(this.childBody);
-    } else {
-        this.body.removeChild(this.childBody);
+        this.body.removeChild(this.revelationBody);
+        this.revelation = null;
+        this.revelationBody = null;
+    }
+    if (value) {
+        this.revelationScope = this.scope.nestComponents();
+        this.revelationBody = this.body.ownerDocument.createBody();
+        this.revelation = new this.Revelation(this.revelationBody, this.revelationScope);
+        this.revelationScope.add(this.revelation, "revelation", this.scope);
+        this.body.appendChild(this.revelationBody);
     }
 };
 
-Reveal.prototype.constructChild = function () {
-    var body = this.body;
-    var constructor = this.childConstructor;
-    this.childBody = body.ownerDocument.createBody();
-    this.child = new constructor(this.childBody, this.scope);
-};
-
 Reveal.prototype.destroy = function () {
-    this.child.destroy();
+    if (this.revelation.destroy) {
+        this.revelation.destroy();
+    }
     this.observer.cancel();
 };

--- a/scope.js
+++ b/scope.js
@@ -18,3 +18,17 @@ Scope.prototype.nestComponents = function () {
     child.components = Object.create(this.components);
     return child;
 };
+
+Scope.prototype.add = function (component, name, scope) {
+    var componentScope = this;
+    do {
+        var id = scope.id + ":" + name;
+        componentScope[id] = component;
+        if (scope.this.add) {
+            scope.this.add(component, id, componentScope);
+        }
+        name = scope.this.exports && scope.this.exports[id];
+        scope = scope.caller;
+        componentScope = componentScope.caller;
+    } while (name);
+};


### PR DESCRIPTION
This factors code out of repeat.js and into scope.js such that it can be
used by repeat, reveal, and choice. All of these primitives now destroy
scopes when they are removed from the document instead of attempting to
reuse them. The intention is to introduce a ``<reuse>`` tag when it becomes
necessary.

- repeat introduces iteration scopes.
- reveal introduces revelation scopes.
- choose introduces choice schopes by the name of the choice.

All introduced scopes cut through transitive caller scopes with the same
export renaming semantics.