### PR TITLE
Fix regex check

### DIFF
--- a/translate.js
+++ b/translate.js
@@ -100,12 +100,7 @@ function analyzeHead(head, program, template, module) {
                         template.exports = href;
                     } else if (rel === "tag") {
                         module.dependencies.push(href);
-                        var as = child.getAttribute("as");
-                        if (!as) {
-                            as = /([^\/]+)(?:\.html|\.xml)$/.exec(href);
-                            as = as[1];
-                        }
-                        as = as.toUpperCase();
+                        var as = getAs(child);
                         var name = as.replace(/[^A-Za-z0-9_]/g, '_');
                         // TODO validate identifier
                         program.add("var $" + name + " = require" + "(" + JSON.stringify(href) + ");\n");
@@ -113,12 +108,7 @@ function analyzeHead(head, program, template, module) {
                         template.addTag(as, {type: "external", id: href, name: name});
                     } else if (rel === "attribute") {
                         module.dependencies.push(href);
-                        var as = child.getAttribute("as");
-                        if (!as) {
-                            as = /([^\/]+)(?:\.html|\.xml)$/.exec(href);
-                            as = as[1];
-                        }
-                        as = as.toUpperCase();
+                        var as = getAs(child);
                         var name = as.replace(/[^A-Za-z0-9_]/g, '_');
                         // TODO validate identifier
                         program.add("var $$" + name + " = require" + "(" + JSON.stringify(href) + ");\n");
@@ -148,6 +138,16 @@ function analyzeHead(head, program, template, module) {
             child = child.nextSibling;
         }
     }
+}
+
+function getAs(node) {
+    var href = node.getAttribute("href");
+    var as = node.getAttribute("as");
+    if (!as) {
+        as = /([^\/]+)(?:\.html|\.xml)$/.exec(href);
+        as = as[1];
+    }
+    return as.toUpperCase();
 }
 
 function analyzeElement(element, program, template, module) {

--- a/translate.js
+++ b/translate.js
@@ -144,8 +144,9 @@ function getAs(node) {
     var href = node.getAttribute("href");
     var as = node.getAttribute("as");
     if (!as) {
-        var match = /([^\/]+)(?:\.html|\.xml)$/.exec(href);
+        var match = /([^\/]+)$/.exec(href);
         as = match[1];
+        as = as.replace(/(?:\.html|\.xml)$/, '');
     }
     return as.toUpperCase();
 }

--- a/translate.js
+++ b/translate.js
@@ -144,8 +144,8 @@ function getAs(node) {
     var href = node.getAttribute("href");
     var as = node.getAttribute("as");
     if (!as) {
-        as = /([^\/]+)(?:\.html|\.xml)$/.exec(href);
-        as = as[1];
+        var match = /([^\/]+)(?:\.html|\.xml)$/.exec(href);
+        as = match[1];
     }
     return as.toUpperCase();
 }


### PR DESCRIPTION
Eliminates:
```
Uncaught TypeError: Can't require module "prompt.html" via "hexant.html" in "hexant" because Cannot read property '1' of null
```

When someone requires e.g. `gutentag/FOO` rather than `gutentag/FOO.html`.